### PR TITLE
論理削除したメールアドレスが新規登録に使えないバグを修正、論理削除用カラムの削除の記述を修正

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
 
 class RegisterController extends Controller
 {
@@ -53,7 +54,13 @@ class RegisterController extends Controller
             'name' => ['required', 'string', 'max:20'],
             'sex' => ['required'],
             'age' => ['required'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email','unique:users,email,Null,id,deleted_at,Null'],
+            'email' => [
+                'required',
+                'string',
+                'email',
+                'max:255',
+                Rule::unique('users', 'email')->whereNull('deleted_at')
+            ],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
         ]);
     }

--- a/database/migrations/2021_10_21_061715_add_column_soft_deletes_users_table.php
+++ b/database/migrations/2021_10_21_061715_add_column_soft_deletes_users_table.php
@@ -28,7 +28,7 @@ class AddColumnSoftDeletesUsersTable extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropCulumn('deleted_at');
+            $table->dropSoftDeletes();
             $table->dropUnique('users_email_unique');
             $table->unique('email','users_email_unique');
         });


### PR DESCRIPTION
・[Laravel] Uniqueバリデーションで、論理削除を考慮するなど、条件をカスタマイズしたい
https://www.yoheim.net/blog.php?q=20190101

・Laravel 6.x バリデーション Rule::unique()について
https://readouble.com/laravel/6.x/ja/validation.html?header=unique:_%25E3%2583%2586%25E3%2583%25BC%25E3%2583%2596%25E3%2583%25AB_,_%25E3%2582%25AB%25E3%2583%25A9%25E3%2583%25A0_,_%25E9%2599%25A4%25E5%25A4%2596ID_,_ID%25E3%2582%25AB%25E3%2583%25A9%25E3%2583%25A0_

・Laravel 6.x データベース：クエリビルダ whereNull()について
https://readouble.com/laravel/6.x/ja/queries.html?header=%25E3%2581%259D%25E3%2581%25AE%25E4%25BB%2596%25E3%2581%25AEWHERE%25E7%25AF%2580

・Laravel でソフトデリートを実装する方法
https://php-junkie.net/framework/laravel/soft-delete/#c-1

・Laravel 6.x データベース：マイグレーション 利用可能な別名コマンド（）
https://readouble.com/laravel/6.x/ja/migrations.html?header=%25E5%2588%25A9%25E7%2594%25A8%25E5%258F%25AF%25E8%2583%25BD%25E3%2581%25AA%25E5%2588%25A5%25E5%2590%258D%25E3%2582%25B3%25E3%2583%259E%25E3%2583%25B3%25E3%2583%2589