### PR TITLE
検索結果のページネーションリンクをクリックした際に、検索結果がリセットされるバグを修正

### DIFF
--- a/resources/views/top.blade.php
+++ b/resources/views/top.blade.php
@@ -100,7 +100,7 @@
 
             @endforeach
 
-            <div class="mt-5">{{ $posts->links() }}</div>
+            <div class="mt-5">{{ $posts->appends(request()->query())->links() }}</div>
 
             @if(empty($posts[0]))
                 検索に一致する投稿はございません。


### PR DESCRIPTION
マニュアル通りにやる場合は以下のとおり
{{ $posts->appends(['category_id' => $category_id,'search' => $search ])->links() }}

記事の方法がスマートだったため採用
（appendsメソッドの引数に指定するクエリ文字列を、Requestクラスのqueryメソッドにより取得）

laravelで検索結果ページネーションを有効にするカンタンな方法
https://blog.dododori.com/create/program/laravel-search-page/

ペジネーションリンクの追加
https://readouble.com/laravel/6.x/ja/pagination.html

クエリストリングからの入力取得
https://readouble.com/laravel/6.x/ja/requests.html