### PR TITLE
ブラウザバックによる二重投稿、投稿後の遷移画面リロードによる二重投稿のバグを修正

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -33,7 +33,8 @@ class PostController extends Controller
         $post->user_id = Auth::id();
         $post->fill($request->all())->save();
 
-        return $this->showMyPosts(1);
+        $request->session()->regenerateToken();
+        return redirect()->route('profile.myposts',1);
     }
 
     public function show(Post $post)


### PR DESCRIPTION
Laravelで二重登録を阻止する3つの方法
https://developers.tam-bourine.co.jp/entry/2020/08/24/120000

セッションIDの再生成 session()->regenerate()
https://readouble.com/laravel/6.x/ja/session.html