### PR TITLE
投稿内容編集・削除後の遷移ページURLの表記について修正

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -95,7 +95,7 @@ class PostController extends Controller
         $this->authorize('update', $post);
         $post->fill($request->all())->save();
 
-        return $this->showMyPosts(1);
+        return redirect()->route('profile.myposts',1);
     }
 
     public function destroy(Post $post)
@@ -104,7 +104,7 @@ class PostController extends Controller
 
         $post->delete();
 
-        return $this->showMyPosts(1);
+        return redirect()->route('profile.myposts',1);
     }
 
 }


### PR DESCRIPTION
投稿内容を編集・削除後、遷移ページ（profile/myposts/）のパスを表示して欲しいところ、以下「修正前」のとおり異なるURLが表示されてしまうため、redirectへルパを使用し、遷移ページのパスを表示するように修正

○ 修正前
・編集後の遷移ページ
（メソッド）return $this->showMyPosts(1);
（URL）http://127.0.0.1:8000/posts/update/139

・削除後の遷移ページ
（メソッド）return $this->showMyPosts(1);
（URL）http://127.0.0.1:8000/posts/destroy/139

○ 修正後
・編集後の遷移ページ
（メソッド）return redirect()->route('profile.myposts',1);
（URL）http://127.0.0.1:8000/profile/myposts/1

・削除後の遷移ページ
（メソッド）return redirect()->route('profile.myposts',1);
（URL）http://127.0.0.1:8000/profile/myposts/1

Laravel 6.x HTTPリダイレクト
https://readouble.com/laravel/6.x/ja/redirects