### PR TITLE
投稿に投稿日時を表示

### DIFF
--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -49,7 +49,14 @@
                             @endcan
                         </div>
                     </div>
-                    <span class="ml-3 h4">{{ $post->title }}</span>
+                    <div class="d-flex justify-content-between ">
+                        <span class="ml-3 mb-0 h4">{{ $post->title }}</span>
+                        @if($post->created_at)
+                            <div class="text-secondary">
+                                {{ $post->created_at->format('Y/n/j H:i') }}
+                            </div>
+                        @endif
+                    </div>
                 </div>
 
                 <ul>
@@ -177,7 +184,12 @@
                     </div>
                     <div>
                         <div class="d-flex align-items-center ml-2 mb-2">
-                            <div>{{ $comment->user->name }}</div>
+                            <div>
+                                {{ $comment->user->name }}
+                            </div>
+                            <div class="ml-3 text-secondary">
+                                {{ $comment->created_at->format('Y/n/j H:i') }}
+                            </div>
                             <div>
                                 @if( $post->user_id === Auth::id() || $comment->user_id === Auth::id() )
                                 {{-- コメント削除 --}}

--- a/resources/views/profile/myposts.blade.php
+++ b/resources/views/profile/myposts.blade.php
@@ -72,6 +72,11 @@
                                 <div class="ml-3">
                                     コメント：{{ $post->comments->count() }}
                                 </div>
+                                @if($post->created_at)
+                                    <div class="ml-4 text-secondary">
+                                        {{ $post->created_at->format('Y/n/j H:i') }}
+                                    </div>
+                                @endif
                             </div>
                         </div>
                     </div>

--- a/resources/views/top.blade.php
+++ b/resources/views/top.blade.php
@@ -95,6 +95,11 @@
                         <div class="ml-3">
                             コメント：{{ $post->comments->count() }}
                         </div>
+                        @if($post->created_at)
+                            <div class="ml-4 text-secondary">
+                                {{ $post->created_at->format('Y/n/j H:i') }}
+                            </div>
+                        @endif
                     </div>
                 </div>
 


### PR DESCRIPTION
formatメソッド
https://readouble.com/laravel/6.x/ja/blade.html

日付ミューテタ
https://readouble.com/laravel/6.x/ja/eloquent-mutators.html

日付のフォーマット
https://www.php.net/manual/ja/datetime.format.php

（補足）一部のコードにif文を使っている理由
・post->created_at の値が null の場合に、format()メソッドが使えずにエラーになる。
（現状、シーダーで作成したデータは全てcreated_atカラムの値がnullになっている）
・そのため、暫定的にif文で制御しているもの。ダミーデータの作成日時の取扱いは別途考える。
・$comment->created_at については、そもそもダミーデータを作成していないため、if文による制御はしていない。