### PR TITLE
非公開機能の実装

### DIFF
--- a/app/Console/Commands/PostsStatusSet.php
+++ b/app/Console/Commands/PostsStatusSet.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Post;
+
+class PostsStatusSet extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'postsStatusSet:postStatusSet';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'postsの全レコードのstatusに0を挿入';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $posts = Post::all();
+        foreach ($posts as $post) {
+            $post->status = 0;
+            $post->save();
+        }
+    }
+}

--- a/app/Enums/PostStatusType.php
+++ b/app/Enums/PostStatusType.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Enums;
+
+use BenSampo\Enum\Enum;
+
+/**
+ * @method static static OptionOne()
+ * @method static static OptionTwo()
+ * @method static static OptionThree()
+ */
+final class PostStatusType extends Enum
+{
+    const PUBLISHED = 0;
+    const SECRET = 1;
+
+    public static function getDescription($value): string
+    {
+        if ($value === self::PUBLISHED) {
+            return '公開';
+        }
+
+        if ($value === self::SECRET) {
+            return '非公開';
+        }
+
+        return parent::getDescription($value);
+    }
+
+    public static function getValue(string $key)
+    {
+        if ($key === '公開') {
+            return self::PUBLISHED;
+        }
+
+        if ($key === '非公開') {
+            return self::SECRET;
+        }
+
+        return parent::getValue($key);
+    }
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -60,12 +60,14 @@ class PostController extends Controller
             $posts = Post::whereIn('id', Nice::select('post_id')
                 ->where('user_id', Auth::id())
             )
+            ->WhereNotIn('private_post',[1])
             ->latest()->get();
         }elseif($page === 3){
             $page_title = 'コメントした投稿';
             $posts = Post::whereIn('id', Comment::select('post_id')
                 ->where('user_id', Auth::id())
             )
+            ->WhereNotIn('private_post',[1])
             ->latest()->get();
         }else{
             abort(404);

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -29,7 +29,7 @@ class PostController extends Controller
         return view('posts.create_confirm',compact('inputs','page'));
     }
 
-    public function store(Request $request, Post $post)
+    public function store(StorePost $request, Post $post)
     {
         $post->user_id = Auth::id();
         $post->fill($request->all())->save();
@@ -61,14 +61,14 @@ class PostController extends Controller
             $posts = Post::whereIn('id', Nice::select('post_id')
                 ->where('user_id', Auth::id())
             )
-            ->WhereNotIn('status',[PostStatusType::SECRET])
+            ->where('status', '<>', PostStatusType::SECRET)
             ->latest()->get();
         }elseif($page === 3){
             $page_title = 'コメントした投稿';
             $posts = Post::whereIn('id', Comment::select('post_id')
                 ->where('user_id', Auth::id())
             )
-            ->WhereNotIn('status',[PostStatusType::SECRET])
+            ->where('status', '<>', PostStatusType::SECRET)
             ->latest()->get();
         }else{
             abort(404);
@@ -94,7 +94,7 @@ class PostController extends Controller
         return view('posts.edit_confirm', compact('inputs','post','page'));
     }
 
-    public function update(Request $request, Post $post)
+    public function update(StorePost $request, Post $post)
     {
         $this->authorize('update', $post);
         $post->fill($request->all())->save();

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -9,6 +9,7 @@ use App\Models\Nice;
 use App\Models\Comment;
 use App\Models\Category;
 use App\Http\Requests\StorePost;
+use App\Enums\PostStatusType;
 
 class PostController extends Controller
 {
@@ -60,14 +61,14 @@ class PostController extends Controller
             $posts = Post::whereIn('id', Nice::select('post_id')
                 ->where('user_id', Auth::id())
             )
-            ->WhereNotIn('private_post',[1])
+            ->WhereNotIn('status',[PostStatusType::SECRET])
             ->latest()->get();
         }elseif($page === 3){
             $page_title = 'コメントした投稿';
             $posts = Post::whereIn('id', Comment::select('post_id')
                 ->where('user_id', Auth::id())
             )
-            ->WhereNotIn('private_post',[1])
+            ->WhereNotIn('status',[PostStatusType::SECRET])
             ->latest()->get();
         }else{
             abort(404);

--- a/app/Http/Controllers/TopController.php
+++ b/app/Http/Controllers/TopController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\Post;
 use App\Models\Category;
+use App\Enums\PostStatusType;
 
 class TopController extends Controller
 {
@@ -14,8 +15,7 @@ class TopController extends Controller
         $category_id = $request->input('category_id');
 
         $query = Post::query()
-            ->whereNotIn('private_post',[1])
-            ->orWhereNull('private_post');
+            ->whereNotIn('status',[PostStatusType::SECRET]);
 
         $categories = $category->getLists();
 

--- a/app/Http/Controllers/TopController.php
+++ b/app/Http/Controllers/TopController.php
@@ -13,7 +13,10 @@ class TopController extends Controller
         $search = $request->input('search');
         $category_id = $request->input('category_id');
 
-        $query = Post::query();
+        $query = Post::query()
+            ->whereNotIn('private_post',[1])
+            ->orWhereNull('private_post');
+
         $categories = $category->getLists();
 
         // カテゴリ検索

--- a/app/Http/Controllers/TopController.php
+++ b/app/Http/Controllers/TopController.php
@@ -15,7 +15,7 @@ class TopController extends Controller
         $category_id = $request->input('category_id');
 
         $query = Post::query()
-            ->whereNotIn('status',[PostStatusType::SECRET]);
+            ->where('status', '<>', PostStatusType::SECRET);
 
         $categories = $category->getLists();
 

--- a/app/Http/Requests/StorePost.php
+++ b/app/Http/Requests/StorePost.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\PostStatusType;
 use Illuminate\Foundation\Http\FormRequest;
+use BenSampo\Enum\Rules\EnumValue;
 
 class StorePost extends FormRequest
 {
@@ -32,6 +34,7 @@ class StorePost extends FormRequest
             'choose_no_reply' => 'nullable|string|max:100',
             'choose_no_answer' => 'nullable|string|max:200',
             'note' => 'nullable|string|max:200',
+            'status' => [ 'required', 'integer', new EnumValue(PostStatusType::class, false)],
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "require": {
         "php": "^7.2.5|^8.0",
         "barryvdh/laravel-debugbar": "^3.6",
+        "bensampo/laravel-enum": "^1.38",
         "fideloper/proxy": "^4.4",
         "laravel/framework": "^6.20.26",
         "laravel/tinker": "^2.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c58911f2beb959c83d60be6e08c0e9a",
+    "content-hash": "edd79dd37e67ca2b7b242c1536e45eb7",
     "packages": [
         {
             "name": "barryvdh/laravel-debugbar",
@@ -90,6 +90,81 @@
                 }
             ],
             "time": "2021-06-14T14:29:26+00:00"
+        },
+        {
+            "name": "bensampo/laravel-enum",
+            "version": "v1.38.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/BenSampo/laravel-enum.git",
+                "reference": "e3b6120602e6e98584cdee938dca71a8c6b8fab0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/BenSampo/laravel-enum/zipball/e3b6120602e6e98584cdee938dca71a8c6b8fab0",
+                "reference": "e3b6120602e6e98584cdee938dca71a8c6b8fab0",
+                "shasum": ""
+            },
+            "require": {
+                "hanneskod/classtools": "~1.0",
+                "illuminate/support": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0",
+                "laminas/laminas-code": "^3.4",
+                "php": "~7.1"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^2.9",
+                "laravel/framework": "5.6.*|5.7.*|5.8.*|^6.0|^7.0",
+                "orchestra/testbench": "3.6.*|3.7.*|3.8.*|3.9.*|^4.0|^5.0",
+                "phpstan/phpstan": "^0.12.9",
+                "phpunit/phpunit": "^7.5|^8.5",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "BenSampo\\Enum\\EnumServiceProvider"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "BenSampo\\Enum\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Sampson",
+                    "homepage": "https://sampo.co.uk",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Simple, extensible and powerful enumeration implementation for Laravel.",
+            "homepage": "https://github.com/bensampo/laravel-enum",
+            "keywords": [
+                "bensampo",
+                "enum",
+                "laravel",
+                "package",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/BenSampo/laravel-enum/issues",
+                "source": "https://github.com/BenSampo/laravel-enum/tree/v1.38.0"
+            },
+            "time": "2020-06-07T12:26:17+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -455,6 +530,251 @@
                 "source": "https://github.com/fideloper/TrustedProxy/tree/4.4.1"
             },
             "time": "2020-10-22T13:48:01+00:00"
+        },
+        {
+            "name": "hanneskod/classtools",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hanneskod/classtools.git",
+                "reference": "d365ddac0e602027c0471ea292f4ba2afcb49394"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hanneskod/classtools/zipball/d365ddac0e602027c0471ea292f4ba2afcb49394",
+                "reference": "d365ddac0e602027c0471ea292f4ba2afcb49394",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4",
+                "php": ">=7.1",
+                "symfony/finder": "^4|^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "hanneskod\\classtools\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Hannes Forsgård",
+                    "email": "hannes.forsgard@fripost.org"
+                }
+            ],
+            "description": "Find, extract and process classes from file system",
+            "homepage": "https://github.com/hanneskod/classtools",
+            "keywords": [
+                "class finder",
+                "code generator",
+                "metaprogramming",
+                "minimizer"
+            ],
+            "support": {
+                "issues": "https://github.com/hanneskod/classtools/issues",
+                "source": "https://github.com/hanneskod/classtools/tree/1.0"
+            },
+            "time": "2020-03-05T20:41:28+00:00"
+        },
+        {
+            "name": "laminas/laminas-code",
+            "version": "3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-code.git",
+                "reference": "b549b70c0bb6e935d497f84f750c82653326ac77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/b549b70c0bb6e935d497f84f750c82653326ac77",
+                "reference": "b549b70c0bb6e935d497f84f750c82653326ac77",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-eventmanager": "^3.3",
+                "laminas/laminas-zendframework-bridge": "^1.1",
+                "php": "^7.3 || ~8.0.0"
+            },
+            "conflict": {
+                "phpspec/prophecy": "<1.9.0"
+            },
+            "replace": {
+                "zendframework/zend-code": "^3.4.1"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.10.4",
+                "ext-phar": "*",
+                "laminas/laminas-coding-standard": "^1.0.0",
+                "laminas/laminas-stdlib": "^3.3.0",
+                "phpunit/phpunit": "^9.4.2"
+            },
+            "suggest": {
+                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
+                "laminas/laminas-stdlib": "Laminas\\Stdlib component"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Extensions to the PHP Reflection API, static code scanning, and code generation",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "code",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-code/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-code/issues",
+                "rss": "https://github.com/laminas/laminas-code/releases.atom",
+                "source": "https://github.com/laminas/laminas-code"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-11-30T20:16:31+00:00"
+        },
+        {
+            "name": "laminas/laminas-eventmanager",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-eventmanager.git",
+                "reference": "a93fd278c97b2d41ebbce5ba048a24e3e6f580ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/a93fd278c97b2d41ebbce5ba048a24e3e6f580ba",
+                "reference": "a93fd278c97b2d41ebbce5ba048a24e3e6f580ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+            },
+            "conflict": {
+                "zendframework/zend-eventmanager": "*"
+            },
+            "require-dev": {
+                "container-interop/container-interop": "^1.1",
+                "laminas/laminas-coding-standard": "~2.2.1",
+                "laminas/laminas-stdlib": "^3.6",
+                "phpbench/phpbench": "^1.1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5.5"
+            },
+            "suggest": {
+                "container-interop/container-interop": "^1.1, to use the lazy listeners feature",
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-eventmanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-eventmanager/issues",
+                "rss": "https://github.com/laminas/laminas-eventmanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-eventmanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-07T22:35:32+00:00"
+        },
+        {
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "7f049390b756d34ba5940a8fb47634fbb51f79ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/7f049390b756d34ba5940a8fb47634fbb51f79ab",
+                "reference": "7f049390b756d34ba5940a8fb47634fbb51f79ab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4, <8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.14",
+                "psalm/plugin-phpunit": "^0.15.2",
+                "squizlabs/php_codesniffer": "^3.6.2",
+                "vimeo/psalm": "^4.21.0"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "support": {
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
+                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
+                "source": "https://github.com/laminas/laminas-zendframework-bridge"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-02-22T22:17:01+00:00"
         },
         {
             "name": "laravel/framework",
@@ -6743,5 +7063,5 @@
         "php": "^7.2.5|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/config/app.php
+++ b/config/app.php
@@ -225,7 +225,7 @@ return [
         'URL' => Illuminate\Support\Facades\URL::class,
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,
-
+        'PostStatusType'=>App\Enums\PostStatusType::class,
     ],
 
 ];

--- a/database/migrations/2021_10_10_131539_create_posts_table.php
+++ b/database/migrations/2021_10_10_131539_create_posts_table.php
@@ -26,7 +26,6 @@ class CreatePostsTable extends Migration
             $table->string('choose_no_answer')->nullable();
             $table->string('note')->nullable();
             $table->timestamps();
-            $table->integer('private_post')->nullable();
 
             $table->foreign('user_id')
                 ->references('id')->on('users')

--- a/database/migrations/2021_10_10_131539_create_posts_table.php
+++ b/database/migrations/2021_10_10_131539_create_posts_table.php
@@ -26,6 +26,7 @@ class CreatePostsTable extends Migration
             $table->string('choose_no_answer')->nullable();
             $table->string('note')->nullable();
             $table->timestamps();
+            $table->integer('private_post')->nullable();
 
             $table->foreign('user_id')
                 ->references('id')->on('users')

--- a/database/migrations/2022_02_23_080139_add_status_to_posts_table.php
+++ b/database/migrations/2022_02_23_080139_add_status_to_posts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddStatusToPostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->integer('status')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/migrations/2022_02_23_080139_add_status_to_posts_table.php
+++ b/database/migrations/2022_02_23_080139_add_status_to_posts_table.php
@@ -26,7 +26,7 @@ class AddStatusToPostsTable extends Migration
     public function down()
     {
         Schema::table('posts', function (Blueprint $table) {
-            //
+            $table->dropColumn('status');
         });
     }
 }

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -624,6 +624,12 @@ class UsersTableSeeder extends Seeder
                 'age' => '0',
                 'email' => 'test@gmail.com',
                 'password' => Hash::make('test'),
+            ],[
+                'name' => 'テスト2',
+                'sex' => '9',
+                'age' => '0',
+                'email' => 'test2@gmail.com',
+                'password' => Hash::make('test2'),
             ]
         ]);
     }

--- a/resources/views/components/post.blade.php
+++ b/resources/views/components/post.blade.php
@@ -365,9 +365,9 @@
                 </div>
 
                 {{-- 非公開設定 --}}
-                <select name="private_post" id="" class="ml-3">
-                    <option value="0">公開</option>
-                    <option value="1">非公開</option>
+                <select name="status" id="" class="ml-3">
+                    <option value="{{ PostStatusType::PUBLISHED }}">公開</option>
+                    <option value="{{ PostStatusType::SECRET }}">非公開</option>
                 </select>
             </div>
 

--- a/resources/views/components/post.blade.php
+++ b/resources/views/components/post.blade.php
@@ -312,55 +312,63 @@
                 <textarea name="note" class="form-control" rows="3">{{ old('note', optional($post)->note) }}</textarea>
             </div>
 
+            <div class="d-flex">
 
-            {{-- 共通のコツ --}}
-            <div class="mb-4 pl-4">
-                <button class="btn btn-outline-info" type="button" data-toggle="collapse" data-target="#collapseCommonTricks" aria-expanded="false" aria-controls="collapseCommonTricks">
-                    共通のコツ
-                </button>
-                <div class="collapse" id="collapseCommonTricks">
-                    <div class="card mt-1">
-                        <div class="card-header p-2">
-                            （可能であれば）相手への共感も示しましょう。
-                        </div>
-                        <div class="card-body p-2">
-                            <p class="card-text">
-                                共感されると、相手は自分の意見を受け入れやすくなります。
-                            </p>
-                        </div>
-                        <div class="card-body p-2">
-                            <p class="card-text">
-                                【 例 】<br>
-                                「あなたの気持ちも分かる」<br>
-                                「面倒くさい気持ちも分かる」<br>
-                                「あなたが仕事で疲れているのも分かる」etc...<br>
-                            </p>
-                        </div>
-                        <div class="card-header p-2">
-                            「私は」を主語にしましょう。
-                        </div>
-                        <div class="card-body p-2">
-                            <p class="card-text">
-                                「あなたは」を主語にすると攻撃的になりやすいです。
-                            </p>
-                        </div>
-                        <div class="card-body p-2">
-                            <p class="card-text">
-                                【 例 】<br>
-                                「あなたはいつも...」「どうしてあなたは...」etc...<br>
-                            </p>
-                        </div>
-                        <div class="card-header p-2">
-                            次のような表現は攻撃的になりやすいので控えましょう。
-                        </div>
-                        <div class="card-body p-2">
-                            <p class="card-text">
-                                【 例 】<br>
-                                「どうして」「なんで」「いつも」「あなたは」etc...
-                            </p>
+                {{-- 共通のコツ --}}
+                <div class="mb-4 pl-4">
+                    <button class="btn btn-outline-info" type="button" data-toggle="collapse" data-target="#collapseCommonTricks" aria-expanded="false" aria-controls="collapseCommonTricks">
+                        共通のコツ
+                    </button>
+                    <div class="collapse" id="collapseCommonTricks">
+                        <div class="card mt-1">
+                            <div class="card-header p-2">
+                                （可能であれば）相手への共感も示しましょう。
+                            </div>
+                            <div class="card-body p-2">
+                                <p class="card-text">
+                                    共感されると、相手は自分の意見を受け入れやすくなります。
+                                </p>
+                            </div>
+                            <div class="card-body p-2">
+                                <p class="card-text">
+                                    【 例 】<br>
+                                    「あなたの気持ちも分かる」<br>
+                                    「面倒くさい気持ちも分かる」<br>
+                                    「あなたが仕事で疲れているのも分かる」etc...<br>
+                                </p>
+                            </div>
+                            <div class="card-header p-2">
+                                「私は」を主語にしましょう。
+                            </div>
+                            <div class="card-body p-2">
+                                <p class="card-text">
+                                    「あなたは」を主語にすると攻撃的になりやすいです。
+                                </p>
+                            </div>
+                            <div class="card-body p-2">
+                                <p class="card-text">
+                                    【 例 】<br>
+                                    「あなたはいつも...」「どうしてあなたは...」etc...<br>
+                                </p>
+                            </div>
+                            <div class="card-header p-2">
+                                次のような表現は攻撃的になりやすいので控えましょう。
+                            </div>
+                            <div class="card-body p-2">
+                                <p class="card-text">
+                                    【 例 】<br>
+                                    「どうして」「なんで」「いつも」「あなたは」etc...
+                                </p>
+                            </div>
                         </div>
                     </div>
                 </div>
+
+                {{-- 非公開設定 --}}
+                <select name="private_post" id="" class="ml-3">
+                    <option value="0">公開</option>
+                    <option value="1">非公開</option>
+                </select>
             </div>
 
             <button type="submit" class="btn btn-primary mb-4 mx-4">入力内容確認</button>

--- a/resources/views/components/post_confirm.blade.php
+++ b/resources/views/components/post_confirm.blade.php
@@ -153,6 +153,15 @@
                     <input name="note" value="{{ $inputs['note'] }}" type="hidden">
                 </div>
 
+                <div class="mb-5">
+                    @if($inputs['private_post'] === '0')
+                        みんなに公開
+                    @elseif($inputs['private_post'] === '1')
+                        非公開
+                    @endif
+                </div>
+                <input name="private_post" value="{{ $inputs['private_post'] }}" type="hidden">
+
                 <div class="mb-4">
                     @if($page === 'create')
                         以上の内容で投稿します（投稿後に編集可能です）

--- a/resources/views/components/post_confirm.blade.php
+++ b/resources/views/components/post_confirm.blade.php
@@ -154,13 +154,13 @@
                 </div>
 
                 <div class="mb-5">
-                    @if($inputs['private_post'] === '0')
+                    @if($inputs['status'] === PostStatusType::PUBLISHED)
                         みんなに公開
-                    @elseif($inputs['private_post'] === '1')
+                    @elseif($inputs['status'] === PostStatusType::SECRET)
                         非公開
                     @endif
                 </div>
-                <input name="private_post" value="{{ $inputs['private_post'] }}" type="hidden">
+                <input name="status" value="{{ $inputs['status'] }}" type="hidden">
 
                 <div class="mb-4">
                     @if($page === 'create')

--- a/resources/views/components/post_list.blade.php
+++ b/resources/views/components/post_list.blade.php
@@ -19,6 +19,10 @@
             <span class="ml-3 h4"><a href="{{ route('top', ['category_id' =>  $post->category->id ])}}" class="badge badge-info badge-pill font-weight-light text-light">{{ $post->category->category_name }}</a></span>
         @endif
 
+        @if($post->private_post === 1)
+            <div>非公開</div>
+        @endif
+
     </div>
 
     <div>

--- a/resources/views/components/post_list.blade.php
+++ b/resources/views/components/post_list.blade.php
@@ -19,7 +19,7 @@
             <span class="ml-3 h4"><a href="{{ route('top', ['category_id' =>  $post->category->id ])}}" class="badge badge-info badge-pill font-weight-light text-light">{{ $post->category->category_name }}</a></span>
         @endif
 
-        @if($post->private_post === 1)
+        @if($post->status === PostStatusType::SECRET)
             <div>非公開</div>
         @endif
 


### PR DESCRIPTION
○ 仕様
・投稿作成・編集画面に公開・非公開のセレクトボックスを設置
・トップ画面及びいいね/コメントした投稿画面において、非公開設定されている投稿の全てが非表示

○ 補足説明
・migrationファイルの変更点について
現状ダミーデータのprivate_postカラムに値をセットしないので、php artisan db:seed でエラーを起こさないようnullableを使っている。

・topの検索用コードの変更点について
上述のとおりダミーデータはnullを許容している
whereNotIn('private_post',[1]) でカラムの値がnullも除外されてしまうため、orWhereNull()でnullも取得している

○ 参考記事
whereNotIn()/orWhereNull()
https://readouble.com/laravel/6.x/ja/queries.html

SQLで「～以外」を指定するには、NOT（否定）とサブクエリの組み合わせ
https://style.potepan.com/articles/25337.html