### PR TITLE
①post_confirmのカテゴリーを表示するコードを修正、②自作したgetListメソッドを削除

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -14,9 +14,9 @@ use App\Enums\PostListType;
 
 class PostController extends Controller
 {
-    public function create(Category $category )
+    public function create()
     {
-        $categories = $category->getLists();
+        $categories = Category::pluck('category_name', 'id');
         $page = 'create';
 
         return view('posts.create',compact('categories','page'));
@@ -24,10 +24,11 @@ class PostController extends Controller
 
     public function createConfirm(StorePost $request)
     {
+        $category = Category::find($request->category_id);
         $inputs = $request->all();
         $page = 'create';
 
-        return view('posts.create_confirm',compact('inputs','page'));
+        return view('posts.create_confirm', compact('category', 'inputs', 'page'));
     }
 
     public function store(StorePost $request, Post $post)
@@ -84,10 +85,10 @@ class PostController extends Controller
         return view('profile.myposts',compact('page_title','posts'));
     }
 
-    public function edit(Category $category, Post $post)
+    public function edit(Post $post)
     {
         $this->authorize('edit', $post);
-        $categories = $category->getLists();
+        $categories = Category::pluck('category_name', 'id');
         $page = 'edit';
 
         return view('posts.edit', compact('post','categories','page'));
@@ -95,10 +96,11 @@ class PostController extends Controller
 
     public function editConfirm(StorePost $request, Post $post)
     {
+        $category = Category::find($request->category_id);
         $inputs = $request->all();
         $page = 'edit';
 
-        return view('posts.edit_confirm', compact('inputs','post','page'));
+        return view('posts.edit_confirm', compact('category', 'inputs', 'post', 'page'));
     }
 
     public function update(StorePost $request, Post $post)

--- a/app/Http/Controllers/TopController.php
+++ b/app/Http/Controllers/TopController.php
@@ -9,7 +9,7 @@ use App\Enums\PostStatusType;
 
 class TopController extends Controller
 {
-    public function index(Category $category, Request $request)
+    public function index(Request $request)
     {
         $search = $request->input('search');
         $category_id = $request->input('category_id');
@@ -17,7 +17,7 @@ class TopController extends Controller
         $query = Post::query()
             ->where('status', '<>', PostStatusType::SECRET);
 
-        $categories = $category->getLists();
+        $categories = Category::pluck('category_name', 'id');
 
         // カテゴリ検索
         if($category_id){

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -6,13 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 
 class Category extends Model
 {
-    public function getLists()
-    {
-        $categories = Category::pluck('category_name', 'id');
-
-        return $categories;
-    }
-
     public function posts()
     {
         return $this->hasMany(Post::class);

--- a/resources/views/components/post_confirm.blade.php
+++ b/resources/views/components/post_confirm.blade.php
@@ -26,43 +26,14 @@
                     <div class="mb-2 text-secondary border-bottom">
                         カテゴリ
                     </div>
+
                     <div class="ml-3">
-                        @if($inputs['category_id'] == 1)
-                        結婚
-                        <input name="category_id" value="{{ $inputs['category_id'] }}" type="hidden">
-                        @elseif($inputs['category_id'] == 2)
-                        育児・家事
-                        <input name="category_id" value="{{ $inputs['category_id'] }}" type="hidden">
-                        @elseif($inputs['category_id'] == 3)
-                        お金
-                        <input name="category_id" value="{{ $inputs['category_id'] }}" type="hidden">
-                        @elseif($inputs['category_id'] == 4)
-                        人間関係
-                        <input name="category_id" value="{{ $inputs['category_id'] }}" type="hidden">
-                        @elseif($inputs['category_id'] == 5)
-                        性生活
-                        <input name="category_id" value="{{ $inputs['category_id'] }}" type="hidden">
-                        @elseif($inputs['category_id'] == 6)
-                        コミュニケーション
-                        <input name="category_id" value="{{ $inputs['category_id'] }}" type="hidden">
-                        @elseif($inputs['category_id'] == 7)
-                        習慣
-                        <input name="category_id" value="{{ $inputs['category_id'] }}" type="hidden">
-                        @elseif($inputs['category_id'] == 8)
-                        仕事
-                        <input name="category_id" value="{{ $inputs['category_id'] }}" type="hidden">
-                        @elseif($inputs['category_id'] == 9)
-                        健康
-                        <input name="category_id" value="{{ $inputs['category_id'] }}" type="hidden">
-                        @elseif($inputs['category_id'] == 10)
-                        モラハラ
-                        <input name="category_id" value="{{ $inputs['category_id'] }}" type="hidden">
-                        @elseif($inputs['category_id'] == 11)
-                        その他
-                        <input name="category_id" value="{{ $inputs['category_id'] }}" type="hidden">
-                        @else
+                        @if(empty($inputs['category_id']))
                         未設定
                         <input name="category_id" value="" type="hidden">
+                        @else
+                        {{ $category->category_name }}
+                        <input name="category_id" value="{{ $inputs['category_id'] }}" type="hidden">
                         @endif
                     </div>
                 </div>


### PR DESCRIPTION
①について
ビューのコードが冗長だったので、該当のカテゴリーのレコードをEloquentで取得し、ビューに渡して使用することでコードを簡略化。

②について
以前に以下の記事を参考にgetListメソッド（categoriesテーブルから、id,category_nameの値を取得するメソッド）をモデルに作成し、コントローラーで呼び出していたが、以下の理由から削除。

○ 理由
・メソッド内のコードがEloquentを使った1行とreturnの1行の計2行のみであり、わざわざモデルにメソッドとして切り出す必要性を感じられなかったため。
・getList()が何をしているかモデルを確認する手間を減らすため。

○ 以前参考にした記事
https://qiita.com/taroth827/items/ba1f541df72c20ae8624