### PR TITLE
①自分の投稿にいいね・コメントがついたら通知がくる機能を実装、②微修正

### DIFF
--- a/app/Enums/PostReadType.php
+++ b/app/Enums/PostReadType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Enums;
+
+use BenSampo\Enum\Enum;
+
+/**
+ * @method static static OptionOne()
+ * @method static static OptionTwo()
+ * @method static static OptionThree()
+ */
+final class PostReadType extends Enum
+{
+    const UNREAD = 0;
+    const READ = 1;
+}

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -6,7 +6,9 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Post;
 use App\Models\Comment;
+use App\Models\Notification;
 use App\Http\Requests\StoreComment;
+use App\Enums\PostReadType;
 
 class CommentController extends Controller
 {
@@ -17,6 +19,14 @@ class CommentController extends Controller
         $comment->post_id = $post->id;
         $comment->comment = $request->comment;
         $comment->save();
+
+        $notification = new Notification();
+        $notification->user_id = $post->user_id;
+        $notification->target_user_id = Auth::id();
+        $notification->post_id = $post->id;
+        $notification->text = '新しいコメントが付きました';
+        $notification->read = PostReadType::UNREAD;
+        $comment->notification()->save($notification);
 
         return redirect()
             ->route('posts.show', $post);

--- a/app/Http/Controllers/NiceController.php
+++ b/app/Http/Controllers/NiceController.php
@@ -2,23 +2,33 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Post;
 use App\Models\Nice;
+use App\Models\Notification;
+use App\Enums\PostReadType;
 
 class NiceController extends Controller
 {
-    public function nice(Post $post, Request $request){
+    public function nice(Post $post){
         $nice = new Nice();
         $nice->post_id = $post->id;
-        $nice->user_id = Auth::user()->id;
+        $nice->user_id = Auth::id();
         $nice->save();
+
+        $notification = new Notification();
+        $notification->user_id = $post->user_id;
+        $notification->target_user_id = Auth::id();
+        $notification->post_id = $post->id;
+        $notification->text = '新しいいいねが付きました';
+        $notification->read = PostReadType::UNREAD;
+        $nice->notification()->save($notification);
+
         return back();
     }
 
-    public function unnice(Post $post, Request $request){
-        $user_id = Auth::user()->id;
+    public function unnice(Post $post){
+        $user_id = Auth::id();
         $nice = Nice::where('post_id', $post->id)->where('user_id', $user_id)->first();
         $nice->delete();
         return back();

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -8,9 +8,11 @@ use App\Models\Post;
 use App\Models\Nice;
 use App\Models\Comment;
 use App\Models\Category;
+use App\Models\Notification;
 use App\Http\Requests\StorePost;
 use App\Enums\PostStatusType;
 use App\Enums\PostListType;
+use App\Enums\PostReadType;
 
 class PostController extends Controller
 {
@@ -42,6 +44,10 @@ class PostController extends Controller
 
     public function show(Post $post)
     {
+        if($post->user_id === Auth::id()){
+            $notifications = Notification::where('post_id', $post->id)
+                ->update(['read' => PostReadType::READ]);
+        }
         $nice = Nice::where('post_id', $post->id)->where('user_id', Auth::id())->first();
 
         return view('posts.show',compact('post','nice'));

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -5,10 +5,22 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\User;
+use App\Models\Notification;
 use App\Http\Requests\StoreProfile;
+use App\Enums\PostReadType;
 
 class ProfileController extends Controller
 {
+    public function notification()
+    {
+        $notifications = Notification::where('user_id', Auth::id())
+            ->where('read', PostReadType::UNREAD)
+            ->latest()->get();
+
+        return view('profile.notifications', compact('notifications'));
+
+    }
+
     public function edit()
     {
         return view('profile.edit');

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -15,4 +15,9 @@ class Comment extends Model
     {
         return $this->belongsTo(Post::class);
     }
+
+    public function notification()
+    {
+        return $this->morphOne('App\Models\Notification', 'notificationable');
+    }
 }

--- a/app/Models/Nice.php
+++ b/app/Models/Nice.php
@@ -15,4 +15,9 @@ class Nice extends Model
     {
         return $this->belongsTo(Post::class);
     }
+
+    public function notification()
+    {
+        return $this->morphOne('App\Models\Notification', 'notificationable');
+    }
 }

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Notification extends Model
+{
+    public function notificationable()
+    {
+        return $this->morphTo();
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -229,6 +229,7 @@ return [
         'PostListType'=>App\Enums\PostListType::class,
         'UserSexType'=>App\Enums\UserSexType::class,
         'PostCategoryType'=>App\Enums\PostCategoryType::class,
+        'Post'=>App\Models\Post::class,
     ],
 
 ];

--- a/database/migrations/2022_03_12_081413_create_notifications_table.php
+++ b/database/migrations/2022_03_12_081413_create_notifications_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateNotificationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('target_user_id');
+            $table->unsignedBigInteger('post_id');
+            $table->morphs('notificationable');
+            $table->string('text');
+            $table->integer('read');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('notifications');
+    }
+}

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -630,6 +630,12 @@ class UsersTableSeeder extends Seeder
                 'age' => '0',
                 'email' => 'test2@gmail.com',
                 'password' => Hash::make('test2'),
+            ],[
+                'name' => 'テスト3',
+                'sex' => '9',
+                'age' => '0',
+                'email' => 'test3@gmail.com',
+                'password' => Hash::make('test3'),
             ]
         ]);
     }

--- a/resources/views/components/profilebar.blade.php
+++ b/resources/views/components/profilebar.blade.php
@@ -49,6 +49,9 @@
                 <div class="mb-4">
                     書いたコメント： <a class="" href="{{ route('profile.myposts', PostListType::MY_COMMENT) }}">{{ Auth::user()->joinCommentsPosts()->count() }}</a> 件
                 </div>
+                <div class="mb-4">
+                    <a class="" href="{{ route('profile.notifications') }}">通知</a>
+                </div>
                 <a class="btn btn-primary mb-1" href="{{ route('posts.create') }}">投稿する</a>
             </div>
 

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -63,7 +63,7 @@
                     <li class="list-unstyled">
                         <div class="mb-4">
                             <div class="mb-2 text-secondary border-bottom">Describe ... 問題や葛藤を描写</div>
-                            @if(empty($post->discribe))
+                            @if(empty($post->describe))
                                 <div class="ml-3 text-secondary">未設定</div>
                             @else
                                 <div class="ml-3">{!! nl2br(e($post->describe)) !!}</div>

--- a/resources/views/profile/notifications.blade.php
+++ b/resources/views/profile/notifications.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row">
+        <div class="col col-lg-8" id="content">
+
+            <div class="text-secondary border-bottom pl-3 pb-1 mb-5 h5">
+                通知
+            </div>
+
+            @if(!isset($notifications[0]))
+                <div class="ml-4">
+                    新しい通知はありません。
+                </div>
+            @else
+                @foreach ($notifications as $notification)
+                    <div>
+                        <a href="{{ route('posts.show', Post::find($notification->post_id)) }}">
+                            「{{ Post::find($notification->post_id)->title }}」に{{ $notification->text }}
+                        </a>
+                    </div>
+                @endforeach
+            @endif
+
+        </div>
+
+        @component('components.profilebar')
+        @endcomponent
+
+    </div>
+</div>
+@endsection

--- a/resources/views/profile/withdraw_confirm.blade.php
+++ b/resources/views/profile/withdraw_confirm.blade.php
@@ -17,9 +17,9 @@
                 </ul>
                 <div class="btn-group d-flex align-items-center ml-5">
 
-                    <form method="post" action="{{ route('profile.withdraw',Auth::user()->id) }}" id="delete_{{ Auth::user()->id }}">
+                    <form method="post" action="{{ route('profile.withdraw' ,Auth::id()) }}" id="delete_{{ Auth::id() }}">
                         @csrf
-                        <a href="#" data-id="{{ Auth::user()->id }}" onclick="deleteUser(this);" class="btn btn-secondary">退会する</a>
+                        <a href="#" data-id="{{ Auth::id() }}" onclick="deleteUser(this);" class="btn btn-secondary">退会する</a>
                     </form>
                     <div class="ml-3">
                         <a href="/">トップに戻る</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,7 @@ Route::group(['prefix' => 'posts','middleware'=>'auth'],function(){
 
 Route::group(['prefix' => 'profile','middleware'=>'auth'],function(){
     Route::get('myposts/{page}', 'PostController@showMyPosts')->name('profile.myposts');
+    Route::get('notifications', 'ProfileController@notification')->name('profile.notifications');
     Route::get('edit', 'ProfileController@edit')->name('profile.edit');
     Route::post('update', 'ProfileController@update')->name('profile.update');
     Route::get('withdraw_confirm','ProfileController@withdrawConfirm')->name('profile.withdraw_confirm');


### PR DESCRIPTION
①について
・ユーザーがいいね・コメントをするとnotificationsテーブルにレコードが挿入される。
・notificationsのreadカラムで未読・既読の判定。
・該当の投稿を投稿主が確認（posts.showにアクセス）すると、readカラムが既読（0 → 1）になる。
・profile.notificationsから未読の通知を確認できる。

Laravel Polymorphicリレーション完全理解
https://reffect.co.jp/laravel/perfect-understanding-polymorphic#Post-2

１対１（ポリモーフィック）
https://readouble.com/laravel/6.x/ja/eloquent-relationships.html#one-to-one-polymorphic-relations

②について
・userのseederにダミーデータ（テスト3）を追加
・「Auth::user()->id」 → 「Auth::id()」 に変更
・未使用のインスタンス（$request）を削除