### PR TITLE
投稿の表示順序の変更をボタンを押さずにsubmitさせる、投稿編集画面において「公開・非公開・下書き」のセレクトボックスの値を維持

### DIFF
--- a/resources/views/components/post.blade.php
+++ b/resources/views/components/post.blade.php
@@ -287,9 +287,9 @@
                 <div class="c-form-group__title">公開 or 非公開 or 下書き</div>
             </div>
             <select name="status" id="" class="e-form">
-                <option value="{{ PostStatusType::PUBLISHED }}" @if(optional($post)->status === PostStatusType::PUBLISHED) selected @endif>公開</option>
-                <option value="{{ PostStatusType::SECRET }}" @if(optional($post)->status === PostStatusType::SECRET) selected @endif>非公開</option>
-                <option value="{{ PostStatusType::DRAFT }}" @if(optional($post)->status === PostStatusType::DRAFT) selected @endif>下書き</option>
+                @foreach(PostStatusType::getInstances() as $instance)
+                    <option value="{{ $instance->value }}" @if(optional($post)->status === $instance->value) selected @endif>{{ $instance->description }}</option>
+                @endforeach
             </select>
         </div>
 

--- a/resources/views/components/post.blade.php
+++ b/resources/views/components/post.blade.php
@@ -287,9 +287,9 @@
                 <div class="c-form-group__title">公開 or 非公開 or 下書き</div>
             </div>
             <select name="status" id="" class="e-form">
-                <option value="{{ PostStatusType::PUBLISHED }}">公開</option>
-                <option value="{{ PostStatusType::SECRET }}">非公開</option>
-                <option value="{{ PostStatusType::DRAFT }}">下書き</option>
+                <option value="{{ PostStatusType::PUBLISHED }}" @if(optional($post)->status === PostStatusType::PUBLISHED) selected @endif>公開</option>
+                <option value="{{ PostStatusType::SECRET }}" @if(optional($post)->status === PostStatusType::SECRET) selected @endif>非公開</option>
+                <option value="{{ PostStatusType::DRAFT }}" @if(optional($post)->status === PostStatusType::DRAFT) selected @endif>下書き</option>
             </select>
         </div>
 

--- a/resources/views/top.blade.php
+++ b/resources/views/top.blade.php
@@ -28,7 +28,7 @@
                     </div>
 
                     <div class="col-md-2">
-                        <select name="sorting" class="e-form">
+                        <select name="sorting" class="e-form" onchange="submit(this.form)">
                             <option value="{{ SortType::LATEST }}" @if(request()->sorting == SortType::LATEST) selected @endif>投稿日時が新しい順</option>
                             <option value="{{ SortType::OLDEST }}" @if(request()->sorting == SortType::OLDEST) selected @endif>投稿日時が古い順</option>
                             <option value="{{ SortType::NICE_DESC }}" @if(request()->sorting == SortType::NICE_DESC) selected @endif>いいねが多い順</option>


### PR DESCRIPTION
【HTML/JS】selectタグで囲んだ内容を選択後にボタンを押さずにsubmitして、遷移させる方法
https://note.com/code82/n/n893fc0cbd771