### PR TITLE
カラムに外部キー制約、カラム名の変更、ヘッダーのcssを修正、その他微修正

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -17,7 +17,7 @@ class PostController extends Controller
 {
     public function create()
     {
-        $categories = Category::pluck('category_name', 'id');
+        $categories = Category::pluck('name', 'id');
         $page = 'create';
 
         return view('posts.create',compact('categories','page'));
@@ -99,7 +99,7 @@ class PostController extends Controller
     public function edit(Post $post)
     {
         $this->authorize('edit', $post);
-        $categories = Category::pluck('category_name', 'id');
+        $categories = Category::pluck('name', 'id');
         $page = 'edit';
 
         return view('posts.edit', compact('post','categories','page'));

--- a/app/Http/Controllers/TopController.php
+++ b/app/Http/Controllers/TopController.php
@@ -20,7 +20,7 @@ class TopController extends Controller
         $query = Post::query()
             ->whereNotIn('status', [PostStatusType::SECRET, PostStatusType::DRAFT]);
 
-        $categories = Category::pluck('category_name', 'id');
+        $categories = Category::pluck('name', 'id');
 
         // カテゴリ検索
         if($category_id){

--- a/database/migrations/2022_06_29_092251_add_foreign_key_to_posts_table.php
+++ b/database/migrations/2022_06_29_092251_add_foreign_key_to_posts_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignKeyToPostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->foreign('category_id')
+                ->references('id')->on('categories')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/migrations/2022_06_29_093034_add_foreign_key_to_notifications_table.php
+++ b/database/migrations/2022_06_29_093034_add_foreign_key_to_notifications_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignKeyToNotificationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('notifications', function (Blueprint $table) {
+            $table->foreign('user_id')
+                ->references('id')->on('users')
+                ->onDelete('cascade');
+
+            $table->foreign('target_user_id')
+                ->references('id')->on('users')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('notifications', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/migrations/2022_06_29_101453_rename_category_name_to_name_on_categories_table.php
+++ b/database/migrations/2022_06_29_101453_rename_category_name_to_name_on_categories_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameCategoryNameToNameOnCategoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->renameColumn('category_name', 'name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->renameColumn('name', 'category_name');
+        });
+    }
+}

--- a/database/seeds/CategoriesTableSeeder.php
+++ b/database/seeds/CategoriesTableSeeder.php
@@ -14,37 +14,37 @@ class CategoriesTableSeeder extends Seeder
         DB::table('categories')->insert([
             [
                 'id' => '1',
-                'category_name' => '結婚',
+                'name' => '結婚',
             ],[
                 'id' => '2',
-                'category_name' => '育児・家事',
+                'name' => '育児・家事',
             ],[
                 'id' => '3',
-                'category_name' => 'お金',
+                'name' => 'お金',
             ],[
                 'id' => '4',
-                'category_name' => '人間関係',
+                'name' => '人間関係',
             ],[
                 'id' => '5',
-                'category_name' => '性生活',
+                'name' => '性生活',
             ],[
                 'id' => '6',
-                'category_name' => 'コミュニケーション',
+                'name' => 'コミュニケーション',
             ],[
                 'id' => '7',
-                'category_name' => '習慣',
+                'name' => '習慣',
             ],[
                 'id' => '8',
-                'category_name' => '仕事',
+                'name' => '仕事',
             ],[
                 'id' => '9',
-                'category_name' => '健康',
+                'name' => '健康',
             ],[
                 'id' => '10',
-                'category_name' => 'モラハラ',
+                'name' => 'モラハラ',
             ],[
                 'id' => '11',
-                'category_name' => 'その他',
+                'name' => 'その他',
             ]
         ]);
     }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11064,6 +11064,20 @@ a.e-tag:focus {
 .l-header {
   padding: 10px 40px 10px;
   width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+@media (min-width: 992px) {
+  .l-header {
+    max-width: 960px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .l-header {
+    max-width: 1140px;
+  }
 }
 
 .l-header__nav {
@@ -11072,7 +11086,6 @@ a.e-tag:focus {
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 16px;
 }
 
 @media (min-width: 992px) {

--- a/resources/sass/layouts/_header.scss
+++ b/resources/sass/layouts/_header.scss
@@ -1,6 +1,16 @@
 .l-header {
     padding: 10px 40px 10px;
     width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+
+    @media (min-width: 992px) {
+        max-width: 960px;
+    }
+
+    @media (min-width: 1200px) {
+        max-width: 1140px;
+    }
 
     &__nav {
         position: relative;
@@ -8,7 +18,6 @@
         flex-wrap: wrap;
         align-items: center;
         justify-content: space-between;
-        padding: 8px 16px;
 
         @media (min-width: 992px) {
             flex-flow: row nowrap;

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,4 +1,4 @@
-<nav class="l-header__nav navbar-light">
+<nav class="l-header__nav">
     <a class="l-header__nav__top" href="{{ url('/') }}">{{ config('app.name', 'Laravel') }}</a>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">

--- a/resources/views/components/post.blade.php
+++ b/resources/views/components/post.blade.php
@@ -39,9 +39,9 @@
             </div>
             <select name="category_id" class="e-form">
                 <option class="e-form" value="">未選択</option>
-                @foreach($categories as $id => $category_name)
+                @foreach($categories as $id => $name)
                     <option value="{{ $id }}" @if(optional($post)->category_id == $id) selected @endif>
-                        {{ $category_name }}
+                        {{ $name }}
                     </option>
                 @endforeach
             </select>

--- a/resources/views/components/post_confirm.blade.php
+++ b/resources/views/components/post_confirm.blade.php
@@ -32,7 +32,7 @@
                     未設定
                     <input name="category_id" value="" type="hidden">
                     @else
-                    {{ $category->category_name }}
+                    {{ $category->name }}
                     <input name="category_id" value="{{ $inputs['category_id'] }}" type="hidden">
                     @endif
                 </div>

--- a/resources/views/components/post_list.blade.php
+++ b/resources/views/components/post_list.blade.php
@@ -17,10 +17,10 @@
         <span class="c-post-list__header__title">{{ $post->title }}</span>
 
         <span class="c-post-list__header__category">
-            @if(!isset($post->category->category_name))
+            @if(!isset($post->category->name))
             <span class="e-tag is-tag_gray">カテゴリ未設定</span>
             @else
-            <a href="{{ route('top', ['category_id' => $post->category->id ])}}" class="e-tag is-tag_orange">{{ $post->category->category_name }}</a>
+            <a href="{{ route('top', ['category_id' => $post->category->id ])}}" class="e-tag is-tag_orange">{{ $post->category->name }}</a>
             @endif
         </span>
 

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -28,13 +28,13 @@
         <div class="c-show-detail">
             <div class="c-show-detail__header">
                 <span class="c-show-detail__header__category">
-                    @if(!isset($post->category->category_name))
+                    @if(!isset($post->category->name))
                     <span class="e-tag is-tag_gray">
                         カテゴリ未設定
                     </span>
                     @else
                     <a href="{{ route('top', ['category_id' => $post->category->id]) }}" class="e-tag is-tag_orange">
-                        {{ $post->category->category_name }}
+                        {{ $post->category->name }}
                     </a>
                     @endif
                 </span>

--- a/resources/views/top.blade.php
+++ b/resources/views/top.blade.php
@@ -10,9 +10,9 @@
                 <div class="c-search-form__category">
                     <select name="category_id" class="e-form">
                         <option value="">未選択</option>
-                        @foreach($categories as $id => $category_name)
+                        @foreach($categories as $id => $name)
                             <option value="{{ $id }}" @if($category_id === "$id") selected @endif>
-                                {{ $category_name }}
+                                {{ $name }}
                             </option>
                         @endforeach
                     </select>
@@ -25,7 +25,7 @@
                 <button type="submit" class="e-btn is-btn_blue">検索</button>
             </div>
 
-            <select name="sorting" class="e-form is-form_50">
+            <select name="sorting" class="e-form is-form_50" onchange="submit(this.form)">
                 <option value="{{ SortType::LATEST }}" @if(request()->sorting == SortType::LATEST) selected @endif>投稿日時が新しい順</option>
                 <option value="{{ SortType::OLDEST }}" @if(request()->sorting == SortType::OLDEST) selected @endif>投稿日時が古い順</option>
                 <option value="{{ SortType::NICE_DESC }}" @if(request()->sorting == SortType::NICE_DESC) selected @endif>いいねが多い順</option>


### PR DESCRIPTION
・categories.id と post.category_id の関係は、０または１対多のため、null許容の外部キー制約を付与

「MySQLの外部キー制約、NULLを許容している」
https://urashita.com/archives/33115

・users.id と notifications.user_id , notifications.target_id に外部キー制約を付与

・categories テーブルの「category_name」を「name」に変更

「laravel migration カラム名変更（初心者向け）」
https://qiita.com/kamotetu/items/b28a684ed4eecdb96a31

「カラム変更」
https://readouble.com/laravel/6.x/ja/migrations.html

・ヘッダーの幅の最大値を1140pxに、paddingを修正、不要なクラスの削除

・以下のコミットで修正した内容が一部反映されていなかったため再度修正（ボタンを押さずにsubmitさせる部分）
「投稿の表示順序の変更をボタンを押さずにsubmitさせる、投稿編集画面において「公開・非公開・下書き」のセレクトボックスの値を維持」
commit 3594a182fb9de7e0a815425ded68715662c9c727